### PR TITLE
Cause largest bar to resize to show that there's a change happening

### DIFF
--- a/server/frontend/components/OfferVis.js
+++ b/server/frontend/components/OfferVis.js
@@ -198,6 +198,10 @@ export default class OfferVis extends Component {
 
     bars.transition()
       .duration(1000)
+      .attr("y", y(0))
+      .attr("height", height - y(0))
+      .transition()
+      .duration(1000)
       .attr("y", function(d) { return y(d.value); })
       .attr("height", function(d) { return height - y(d.value); });
   }


### PR DESCRIPTION
Because the y-scale is locked to the max bar height, the bar value my change
but the max will not reflect this in a transition animation. So, we show
all bars go to 0 first before sizing to their new values.